### PR TITLE
Default two precision

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -14,23 +14,34 @@ set_collection(collection=collection)
 
 ## Standard renderer
 
-The `StandardRenderer` is used by default and prints to stdout.
+The `StandardRenderer` is used by default and prints to stdout: 
 
-Instantiate a `renderer` with `StandardRenderer(format: Optional[str] = None)`
+```python
+StandardRenderer(format: Optional[str] = None, out: TextIO = sys.stderr, max_terms: int = 2)
+```
 
-`format` is a regular Python format string describing the desired output. The keys in the format string have to be amongst the available timings aggregates: `"mean"`, `"std"`, `"min"`, `"max"`, `"last"` and `"count"`.
+- `format` is a regular Python format string describing the desired output. See [format strings](#format-string)
+- `out` is a text IO stream to write to
+- `max_terms` controls the number of units to display. `1.3` seconds will be written as `1s` with max_terms = 1 or `1s300ms` with `max_terms = 2`
 
+### Format string
+
+The keys in the format string have to be amongst the available timings aggregates: `"mean"`, `"std"`, `"min"`, `"max"`, `"last"` and `"count"`.
 Two special `formats` are accepted too:
-    - `"short"` corresponding to  `"{mean} count={count}"`
-    - `"long"` corresponding to `"{mean} ({std} std) min={min} max={max} count={count} last={last}"`
+
+- `"short"` corresponding to  `"{mean} count={count}"`
+- `"long"` corresponding to `"{mean} ({std} std) min={min} max={max} count={count} last={last}"`
 
     
 ## Logging renderer
 
-The `LoggingRenderer` is used to render timing information as log messages instead of printing.
+The `LoggingRenderer` is used to render timing information as log messages instead of printing:
 
-Instantiate it with `LoggingRenderer(logger=None, level :str = "INFO", extra_as_kwargs: bool = False)` and set it to the default `ClockCollection`.
+```python
+LoggingRenderer(logger=None, level :str = "INFO", extra_as_kwargs: bool = False)
+```
 
-This will make `ticktock` render all statistics as log messages of the given log level. Statistics are passed as a dictionary to the `extra` attribute of the `logger` by default. As a result you should make sure that your logging handler and formatter correctly outputs the contents of the `extra` dictionary.
+This will make `ticktock` render all statistics as log messages of the given log level. 
+Statistics are passed as a dictionary to the `extra` attribute of the `logger` by default. As a result you should make sure that your logging handler and formatter correctly outputs the contents of the `extra` dictionary.
 
 If your logger accepts keyword arguments to the logging functions (for example with `structlog`), provide your own logger and set `extra_as_kwargs` to `True`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,3 +13,5 @@ isort
 wheel
 bump2version
 twine
+# docs
+mkdocs-material

--- a/scripts/lint-apply.sh
+++ b/scripts/lint-apply.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-set -x
-
-black ticktock tests
-isort ticktock tests

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [[ $1 == apply ]] ; then
+    black ticktock tests
+    isort ticktock tests
+fi
+
 black ticktock tests --check
 isort ticktock tests --check-only
 flake8 ticktock tests 

--- a/ticktock/utils.py
+++ b/ticktock/utils.py
@@ -11,7 +11,7 @@ time_factors = [
 ]
 
 
-def format_ns_interval(v_ns: float, max_terms: int = 1):
+def format_ns_interval(v_ns: float, max_terms: int = 2):
     remainder = v_ns
     out_str = ""
     n_terms = 0


### PR DESCRIPTION
This PR fixes https://github.com/victorbenichoux/ticktock/issues/6 by adding another level of precision to the times that are shown by the `StandardRenderer`.

This can be controlled by setting `max_terms` on the `StandardRenderer`, which defaults to 2.