### PR TITLE
More formatting options

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -68,6 +68,18 @@ from ticktock import set_format
 set_format(max_terms = 3)
 ```
 
+### Raw time fields
+
+You can access the raw (floating point) values of the time aggregates as keys in the `format` string as well.
+
+These are all recorded in nanoseconds (unless you specified a different `timer` function):
+
+- `avg_time_ns`:the average of all past time intervals
+- `std_time_ns`: the standard deviation of all past time intervals
+- `min_time_ns`: the minimum measured time
+- `max_time_ns`: the maximum measured time
+- `last_time_ns`: the last measured time
+
 
 ### Updated lines
 

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -24,7 +24,9 @@ Equivalently, to globally set the format string, set the `TICKTOCK_DEFAULT_FORMA
 ### Format string keys
 
 
-The keys in the format string have to be one the available timing aggregates: 
+The keys in the format string have to be amongst the available attributes, and will be replaced by their value at render.
+
+Keys are of two distinct types, *time keys* and normal keys. Time keys will be replaced by a string representing the timing value with its unit attached:
 
 - `mean`: the average of all past time intervals
 - `std`: the standard deviation of all past time intervals
@@ -33,12 +35,25 @@ The keys in the format string have to be one the available timing aggregates:
 - `last`: the last measured time
 - `count`: the numer of intervals measured.
 
-Each of the keys will be replaced by a string representing the timing value with its unit attached. 
+Normal keys have properties related to the position of the tick or tock:
+
+- `tick_name`: the tick name if set when calling `tick`, otherwise equal to `{tick_filename}:{tick_line}`
+- `tock_name`: the tock name if set when calling `tock`, otherwise equal to `{tock_line}`
+- `tick_line`: the line at which `tick` was called in your code
+- `tock_line`: the line at which `tock` was called in your code
+- `tick_filename`: the name of the file in which `tick` was called
+- `tock_filename`: the name of the file in which `tock` was called
 
 In addition, two special cased formats are accepted too:
 
-- `short` corresponding to  `"{mean} count={count}"`
-- `long` corresponding to `"{mean} ({std} std) min={min} max={max} count={count} last={last}"`
+- `short` with just the average time and the count 
+```python
+"⏱️ [{tick_name}-{tock_name}] {mean} count={count}"
+```
+- `long` corresponding to 
+```python
+"⏱️ [{tick_name}-{tock_name}] {mean} ({std} std) min={min} max={max} count={count} last={last}"
+```
 
 ### Units
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -57,7 +57,10 @@ def test_file_rendering_custom(incremental_timer):
                 renderer=StandardRenderer(out=f),
             )
             set_collection(collection)
-            set_format("{mean} {min} {max} {std} {last} {count}", max_terms=1)
+            set_format(
+                "⏱️ [{tick_name}-{tock_name}] {mean} {min} {max} {std} {last} {count}",
+                max_terms=1,
+            )
             for _ in range(10):
                 t = tick(name="start", collection=collection, timer=incremental_timer)
                 t.tock("end")

--- a/ticktock/data.py
+++ b/ticktock/data.py
@@ -6,6 +6,9 @@ from typing import Dict
 @dataclass
 class AggregateTimes:
     tock_name: str
+    tock_filename: str
+    tock_line: int
+
     avg_time_ns: float
     min_time_ns: float
     max_time_ns: float
@@ -41,3 +44,5 @@ class AggregateTimes:
 class ClockData:
     times: Dict[str, AggregateTimes]
     tick_name: str
+    tick_filename: str
+    tick_line: int

--- a/ticktock/renderers.py
+++ b/ticktock/renderers.py
@@ -35,6 +35,11 @@ FIELDS = {
     "tock_line": lambda clock_data, times: times.tock_line,
     "tick_filename": lambda clock_data, times: clock_data.tick_filename,
     "tock_filename": lambda clock_data, times: times.tock_filename,
+    "avg_time_ns": lambda clock_data, times: times.avg_time_ns,
+    "std_time_ns": lambda clock_data, times: times.std_time_ns,
+    "min_time_ns": lambda clock_data, times: times.min_time_ns,
+    "max_time_ns": lambda clock_data, times: times.max_time_ns,
+    "last_time_ns": lambda clock_data, times: times.last_time_ns,
 }
 
 

--- a/ticktock/renderers.py
+++ b/ticktock/renderers.py
@@ -28,7 +28,13 @@ TIME_FIELDS = {
 }
 
 FIELDS = {
-    "count": lambda times: times.n_periods,
+    "count": lambda clock_data, times: times.n_periods,
+    "tick_name": lambda clock_data, times: clock_data.tick_name,
+    "tock_name": lambda clock_data, times: times.tock_name,
+    "tick_line": lambda clock_data, times: clock_data.tick_line,
+    "tock_line": lambda clock_data, times: times.tock_line,
+    "tick_filename": lambda clock_data, times: clock_data.tick_filename,
+    "tock_filename": lambda clock_data, times: times.tock_filename,
 }
 
 
@@ -38,8 +44,10 @@ class AbstractRenderer(abc.ABC):
 
 
 FORMATS = {
-    "short": "{mean} count={count}",
-    "long": "{mean} ({std} std) min={min} max={max} count={count} last={last}",
+    "short": "⏱️ [{tick_name}-{tock_name}] {mean} count={count}",
+    "long": "⏱️ [{tick_name}-{tock_name}] "
+    "{mean} ({std} std) min={min} max={max}"
+    " count={count} last={last}",
 }
 
 
@@ -108,8 +116,7 @@ class StandardRenderer(AbstractRenderer):
     def render_times(self, clock_data: ClockData) -> Iterable[str]:
         for times in clock_data.times.values():
             yield (
-                "⏱️ "
-                + f"[{clock_data.tick_name}-{times.tock_name}] "
+                ""
                 + self._format.format(
                     **{
                         key: format_ns_interval(
@@ -117,7 +124,9 @@ class StandardRenderer(AbstractRenderer):
                         )
                         for key in self._time_fields
                     },
-                    **{key: str(FIELDS[key](times)) for key in self._fields},
+                    **{
+                        key: str(FIELDS[key](clock_data, times)) for key in self._fields
+                    },
                 )
             )
 

--- a/ticktock/timer.py
+++ b/ticktock/timer.py
@@ -8,27 +8,9 @@ from typing import Callable, Dict, Optional, Tuple
 
 from ticktock.data import AggregateTimes, ClockData
 from ticktock.renderers import AbstractRenderer, StandardRenderer
-from ticktock.utils import value_from_env
+from ticktock.utils import get_frame_info, value_from_env
 
 logger = logging.getLogger("ticktock.timer")
-
-
-def get_frame_info(level: int = 1) -> Tuple[str, int]:
-    frame = inspect.currentframe()
-    if frame:
-        for _ in range(level + 1):
-            if not frame:
-                return "<no frame info>", -1
-            frame = frame.f_back
-        if not frame:
-            return "<no frame info>", -1
-        return (
-            frame.f_code.co_filename,
-            frame.f_lineno,
-        )
-    else:
-        return "<no frame info>", -1
-
 
 _ALL_COLLECTIONS = []
 

--- a/ticktock/utils.py
+++ b/ticktock/utils.py
@@ -1,4 +1,6 @@
+import inspect
 import os
+from typing import Tuple
 
 time_factors = [
     (24 * 60 * 60 * 1e9, "d"),
@@ -29,3 +31,20 @@ def value_from_env(env_var: str, default):
     if env_var in os.environ:
         return type(default)(os.environ[env_var])
     return default
+
+
+def get_frame_info(level: int = 1) -> Tuple[str, int]:
+    frame = inspect.currentframe()
+    if frame:
+        for _ in range(level + 1):
+            if not frame:
+                return "<no frame info>", -1
+            frame = frame.f_back
+        if not frame:
+            return "<no frame info>", -1
+        return (
+            frame.f_code.co_filename,
+            frame.f_lineno,
+        )
+    else:
+        return "<no frame info>", -1


### PR DESCRIPTION
This PR introduces more formatting options, by enabling the user to choose amongst more keys, for example the tick line, tock line, but also the raw timings. 

This added flexibility adds a bit more constraints: in particular, format strings should also contain the clock name part:
```python
set_format("⏱️ [{tick_name}-{tock_name}] {mean} ({std} std) min={min} max={max} count={count} last={last}")
```


There are also a couple of minor refactorizations.