### PR TITLE
MultipleRenderers - delegates rendering to multiple renderers

### DIFF
--- a/ticktock/renderers.py
+++ b/ticktock/renderers.py
@@ -18,6 +18,16 @@ class AbstractRenderer(abc.ABC):
         ...
 
 
+class MultipleRenderers(AbstractRenderer):
+    def __init__(self, renderers: List[AbstractRenderer]) -> None:
+        super().__init__()
+        self.renderers = renderers
+
+    def render(self, render_data: List["Clock"]) -> None:
+        for renderer in self.renderers:
+            renderer.render(render_data)
+
+
 TIME_FIELDS = {
     "mean": lambda times: times.avg_time_ns,
     "std": lambda times: times.std_time_ns,


### PR DESCRIPTION
This is a small facade over renderers that we use for e.g. render at the same time to stdout and to external monitoring system. It would be nice to have it in the library