### PR TITLE
Fix name

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -9,8 +9,18 @@ import pytest
 from tests import TEST_DIR
 from ticktock.clocks import tick
 from ticktock.collection import ClockCollection, set_collection, set_format
-from ticktock.renderers import LoggingRenderer
+from ticktock.renderers import LoggingRenderer, name_field_fn
 from ticktock.std import StandardRenderer
+
+
+def test_tick_filename_does_not_exist(fresh_clock_collection):
+    t = tick(collection=fresh_clock_collection)
+    t.tock()
+    clock = next(iter(fresh_clock_collection.clocks.values()))
+    clock.tick_filename = "<something/that/doesnt/exist>"
+    times = next(iter(clock.times.values()))
+
+    assert name_field_fn(clock, times).startswith("<something/that/doesnt/exist>")
 
 
 def compare_text(truth_fn, result_fn):

--- a/ticktock/renderers.py
+++ b/ticktock/renderers.py
@@ -41,10 +41,9 @@ def name_field_fn(clock: "Clock", times: "AggregateTimes"):
     else:
         if os.path.exists(clock.tick_filename):
             tick_name = os.path.basename(clock.tick_filename)
-        if not isinstance(times.tock_name, _TockName):
-            return f"{tick_name}-{times.tock_name}"
         else:
-            return f"{tick_name}:{clock.tick_line}-{times.tock_line}"
+            tick_name = clock.tick_filename
+        return f"{tick_name}:{clock.tick_line}-{times.tock_line}"
 
 
 CONSTANT_FIELDS = {


### PR DESCRIPTION
This fixes a bug encountered when using ticktock in a REPL with unnamed `tick` calls. 

In this context, `clock.tick_filename` does not exist, and `name_field_fn` fails because `tick_name` is used before being defined. This was broken recently.

The first commit adds a test to expose the bug, while the second fixes it.